### PR TITLE
[sy-issue-7] categories 에 antDesign 적용하기 

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 
-const Index = require('./index');
+import Index from './index';
 
 ReactDom.render(<Index/>, document.querySelector('#root'));

--- a/client/categories/sample.jsx
+++ b/client/categories/sample.jsx
@@ -1,1 +1,16 @@
-asd
+import React , { Component } from 'react';
+import {Button} from "antd";
+
+class Categorie extends Component {
+
+  render() {
+    return (
+        <>
+          <h1>Categories</h1>
+          <Button type="primary">Example button</Button>
+        </>
+    );
+  }
+}
+
+export default Categorie;

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,5 +1,4 @@
-const React = require('react');
-const { Component } = React;
+import React ,{ Component } from 'react';
 
 class Index extends Component {
   state = {
@@ -11,4 +10,4 @@ class Index extends Component {
   }
 }
 
-module.exports = Index;
+export default Index;

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,12 +1,19 @@
-import React ,{ Component } from 'react';
+import React, {Component} from 'react';
+import Categorie from './categories/sample';
+import 'antd/dist/antd.less';
 
 class Index extends Component {
   state = {
-    text: "hello, webpack!",
+    text: "hello,!",
   };
 
   render() {
-    return <h1>{this.state.text}</h1>;
+    return (
+        <>
+          <h1>{this.state.text}</h1>
+          <Categorie />
+        </>
+    );
   }
 }
 

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -4,7 +4,7 @@ import 'antd/dist/antd.less';
 
 class Index extends Component {
   state = {
-    text: "hello,!",
+    text: 'hello,!',
   };
 
   render() {

--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,13 @@
   "author": "tripleB",
   "license": "MIT",
   "dependencies": {
+    "antd": "^3.20.3",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "less": "^3.9.0",
+    "less-loader": "^5.0.0"
+    "css-loader": "^3.0.0",
+    "style-loader": "^0.23.1",
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,33 +6,52 @@ module.exports = {
   mode: 'development',
   devtool: 'eval',
   resolve: {
-    extensions: ['.js','.jsx'],
+    extensions: ['.js', '.jsx'],
   },
 
   entry: {
     app: ['./app'],
   },
 
-  module : {
-    rules : [{
-      test: /\.jsx?$/,
-      loader : 'babel-loader',
-      options : {
-        presets:[
-          ['@babel/preset-env', {
-            targets: {
-              browsers: ['> 5% in KR', 'last 2 chrome versions'], // 원하는 브라우저만 선정하겠다. https://github.com/browserslist/browserslist
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: 'babel-loader',
+        options: {
+          presets: [
+            ['@babel/preset-env', {
+              targets: {
+                browsers: ['> 5% in KR', 'last 2 chrome versions'], // 원하는 브라우저만 선정하겠다. https://github.com/browserslist/browserslist
+              },
+              debug: true,
+            }],
+            '@babel/preset-react'
+          ],
+          plugins: [
+            '@babel/plugin-proposal-class-properties',
+            'react-hot-loader/babel',
+            ["import", { "libraryName": "antd", "style": true }],
+          ],
+        }
+      },{
+        test: /\.less?$/,
+        use: [
+          {
+            loader: 'style-loader', // creates style nodes from JS strings
+          },
+          {
+            loader: 'css-loader', // translates CSS into CommonJS
+          },
+          {
+            loader: 'less-loader', // compiles Less to CSS
+            options: {
+              javascriptEnabled: true
             },
-            debug: true,
-          }],
-          '@babel/preset-react'
+          },
         ],
-        plugins:[
-          '@babel/plugin-proposal-class-properties',
-          'react-hot-loader/babel',
-        ],
-      }
-    }],
+      },
+    ],
   },
 
   output: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
           presets: [
             ['@babel/preset-env', {
               targets: {
-                browsers: ['> 5% in KR', 'last 2 chrome versions'], // 원하는 브라우저만 선정하겠다. https://github.com/browserslist/browserslist
+                browsers: ['> 5% in KR', 'last 2 chrome versions'],
               },
               debug: true,
             }],
@@ -38,13 +38,13 @@ module.exports = {
         test: /\.less?$/,
         use: [
           {
-            loader: 'style-loader', // creates style nodes from JS strings
+            loader: 'style-loader',
           },
           {
-            loader: 'css-loader', // translates CSS into CommonJS
+            loader: 'css-loader',
           },
           {
-            loader: 'less-loader', // compiles Less to CSS
+            loader: 'less-loader',
             options: {
               javascriptEnabled: true
             },


### PR DESCRIPTION
#7 require 에서 import 로 변경

- index.jsx 파일 app.jsx 에 모듈로 추가 할 때, require 로 추가하면 index.jsx 파일에서 모듈 추가 시 import 가 안먹음.
 - app.jsx 에서 index.jsx 모듈 추가 시 require 대신 import 로 추가

#7 [antd 라이브러리] '.less' 파일 import

- `import '/antd/dist/antd.less'` 경로 따라서 가 보면 '.less' 파일을 임포트 하는 것을 알 수 있다.
- 해당 파일 내부에 '@import' 를 컴파일 하기 위해 npm 'style-loader', 'css-loader', 'less-loader' 을 추가.
- npm 추가 후에 webpack 에서 스타일 파일들 관리 하기 위한 설정.