### PR TITLE
[sy] React - Node axios 를 이용한 rest 통신 틀 마련

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "async-to-promises"
+  ]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "antd": "^3.20.3",
+    "axios": "^0.19.0",
     "css-loader": "^3.0.0",
     "file-loader": "^4.1.0",
     "jquery": "^3.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "antd": "^3.20.3",
     "axios": "^0.19.0",
+    "babel-plugin-async-to-promises": "^1.0.5",
     "css-loader": "^3.0.0",
     "file-loader": "^4.1.0",
     "jquery": "^3.4.1",
@@ -30,11 +31,13 @@
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-import": "^1.12.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-stage-0": "^6.24.1",
+    "bootstrap": "^4.3.1",
+    "react-bootstrap": "^0.22.6",
     "react-hot-loader": "^4.12.6",
     "webpack": "^4.35.3",
     "webpack-cli": "^3.3.6",
-    "webpack-dev-server": "^3.7.2",
-    "bootstrap": "^4.3.1",
-    "react-bootstrap": "^0.22.6"
+    "webpack-dev-server": "^3.7.2"
   }
 }

--- a/client/src/component/all/Head.jsx
+++ b/client/src/component/all/Head.jsx
@@ -18,16 +18,16 @@ class Head extends Component {
               <ul className="navbar-nav mr-auto">
 
                 <li className="nav-item active">
-                  <a className="nav-link" href="#"><Link to="/">Home</Link> <span
-                      className="sr-only">(current)</span></a>
+                  <Link to="/" className="nav-link"><span
+                      className="sr-only">(current)</span>Home</Link>
                 </li>
 
                 <li className="nav-item">
-                  <a className="nav-link" href="#"><Link to="/report">Report</Link></a>
+                  <Link to="/report" className="nav-link">Report</Link>
                 </li>
 
                 <li className="nav-item">
-                  <a className="nav-link" href="#"><Link to="/dashboard">Dashboard</Link></a>
+                  <Link to="/dashboard" className="nav-link">Dashboard</Link>
                 </li>
 
               </ul>

--- a/client/src/component/dashboard/Categories.jsx
+++ b/client/src/component/dashboard/Categories.jsx
@@ -4,6 +4,15 @@ import {PageHeader, Button, Statistic, Row, Col, Card} from 'antd';
 
 class Categories extends Component {
 
+  state = {
+    userSubscribeeData : [
+      {name: 'melon', price:'6500', Dday:"17"},
+      {name: 'netflex', price:'9800', Dday:"28"},
+      {name: 'watch', price:'5600', Dday:"5"},
+    ]
+  };
+
+
 
   render() {
     return (
@@ -23,35 +32,25 @@ class Categories extends Component {
           <br/>
 
           <div>
-            <Card type="inner" title="Melon" extra={<a href="#">More</a>}>
-              <div className="extraContent">
-                <Row>
-                  <Col span={12}>
-                    <Statistic title="D-Day" value="D-17"/>
-                  </Col>
-                  <Col span={12}>
-                    <Statistic title="Price" prefix="₩" value={6500}/>
-                  </Col>
-                </Row>
-              </div>
-            </Card>
-            <Card
-                style={{marginTop: 16}}
-                type="inner"
-                title="NetFlix"
-                extra={<a href="#">More</a>}
-            >
-              <div className="extraContent">
-                <Row>
-                  <Col span={12}>
-                    <Statistic title="D-Day" value="D-3"/>
-                  </Col>
-                  <Col span={12}>
-                    <Statistic title="Price" prefix="₩" value={9500}/>
-                  </Col>
-                </Row>
-              </div>
-            </Card>
+
+            {this.state.userSubscribeeData.map((ssData,index)=>{
+              return (
+                  <Card key={index} type="inner" title={ssData.name} extra={<a href="#">More</a>}>
+                    <div className="extraContent">
+                      <Row>
+                        <Col span={12}>
+                          <Statistic title="D-Day" value={ssData.Dday}/>
+                        </Col>
+                        <Col span={12}>
+                          <Statistic title="Price" prefix="₩" value={ssData.price}/>
+                        </Col>
+                      </Row>
+                    </div>
+                  </Card>
+              )
+            })}
+
+
           </div>
           <br/>
 

--- a/client/src/pages/dashboard.jsx
+++ b/client/src/pages/dashboard.jsx
@@ -1,20 +1,42 @@
 import React, {Component} from 'react';
-import {Layout} from 'antd';
 
 import Calendar from '../component/dashboard/Calendar';
 import Categories from '../component/dashboard/Categories';
 
-const {Content} = Layout;
+import * as service from '../services/posts';
+
 
 class DashBoard extends Component {
+
+  fetchPostInfo = async (postId) => {
+    const post = await service.getPost(postId);
+    console.log(post);
+    const comments = await service.getComments(postId);
+    console.log(comments);
+  }
 
   render() {
     return (
         <>
-          <Content>
-            <Calendar/>
-            <Categories/>
-          </Content>
+          <div className="container">
+            <div className="row">
+              <div className="col-md-6">
+                <h2>Calendar</h2>
+                <Calendar/>
+              </div>
+              <div className="col-md-6">
+
+                <Categories name="Melon" Dday="17" price="6,500"/>
+
+              </div>
+            </div>
+
+            <hr/>
+
+              <footer>
+                <p>DashBoard</p>
+              </footer>
+          </div>
         </>
     );
   }

--- a/client/src/pages/dashboard.jsx
+++ b/client/src/pages/dashboard.jsx
@@ -18,6 +18,8 @@ class DashBoard extends Component {
     console.log(post);
     const comments = await service.getComments(postId);
     console.log(comments);
+    const hello = await service.getServerHelloWorld();
+    console.log(hello);
   };
 
   render() {

--- a/client/src/pages/dashboard.jsx
+++ b/client/src/pages/dashboard.jsx
@@ -5,15 +5,20 @@ import Categories from '../component/dashboard/Categories';
 
 import * as service from '../services/posts';
 
+import 'babel-polyfill';
 
 class DashBoard extends Component {
+
+  onTest = (value) =>{
+    this.fetchPostInfo(1);
+  }
 
   fetchPostInfo = async (postId) => {
     const post = await service.getPost(postId);
     console.log(post);
     const comments = await service.getComments(postId);
     console.log(comments);
-  }
+  };
 
   render() {
     return (
@@ -30,6 +35,7 @@ class DashBoard extends Component {
 
               </div>
             </div>
+            <button onClick={this.onTest(1)}>test ajax</button>
 
             <hr/>
 

--- a/client/src/services/posts.js
+++ b/client/src/services/posts.js
@@ -5,5 +5,9 @@ export function getPost(postId) {
 }
 
 export function getComments(postId) {
-  return axios.get(`https://jsonplaceholder.typicode.com/posts/${postId}/comments`)
+  return axios.get(`https://jsonplaceholder.typicode.com/posts/${postId}/comments`);
+}
+
+export function getServerHelloWorld() {
+  return axios.get(`http://localhost:5000`);
 }

--- a/client/src/services/posts.js
+++ b/client/src/services/posts.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export function getPost(postId) {
+  return axios.get('https://jsonplaceholder.typicode.com/posts/' + postId);
+}
+
+export function getComments(postId) {
+  return axios.get(`https://jsonplaceholder.typicode.com/posts/${postId}/comments`)
+}

--- a/client/src/static/style/total.css
+++ b/client/src/static/style/total.css
@@ -26,10 +26,6 @@ body {
     height: 100%;
 }
 
-.ant-col-12 {
-    background-color: burlywood;
-}
-
 /*head,app 에 margin 을 주어 겹치지 않게 하려고 설정*/
 .head {
     height: 50px;

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# moneydog
+# moneydog - node server
 
 * 실행 파일  
     > app.js

--- a/server/bin/www
+++ b/server/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT || '5000');
 app.set('port', port);
 
 /**
@@ -26,7 +26,7 @@ var server = http.createServer(app);
  */
 
 server.listen(port, () => {
-  console.log('MoneyDog Server listening on port 3000!');
+  console.log(`MoneyDog Server listening on port ${port}!`);
 });
 server.on('error', onError);
 server.on('listening', onListening);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -4,7 +4,9 @@ var router = express.Router();
 /* GET home page. */
 router.get('/', (req, res, next) => {
   // res.render('index', { title: 'Expresszz' });
-  res.send('Hello World!\n');
+  res.header("Access-Control-Allow-Origin","*");
+  res.header("Access-Control-Allow-Headers","Origin, X-Requested_with, Content-Type, Accept");
+  res.json({name:"melon"});
 });
 
 module.exports = router;


### PR DESCRIPTION
#54 코드 리팩토링 
- Head.jsx 파일에서 LinkTO 태그와 a 태그 중첩 된 부분 리팩토링
- categories.jsx dashboard.jsx 에서 props 와 map 을이용한 반복문 코드 삽2입

#54 ajax 통신을 위한 src/services 폴더 생성
- src/services/posts 에 예제 axios 코드 추가

#54 
- ES8 버전인 async await promise 등을 사용하기 위한 바벨 설정
- dashboard에 ajax 예제 코드 작성 (나중 변경 예정)

#54 
##### server 코드
- index.js 크로스 브라우저 가능하도록 설정 , 하드 코딩 한 값 json 형식으로 restApi 작성

##### client 코드
- service/posts.js 에 server restApi 접근 코드 생성 , dashboard 에서 사용